### PR TITLE
#023 - Fixed query to only show open issues

### DIFF
--- a/src/utils/githubHelper.js
+++ b/src/utils/githubHelper.js
@@ -17,5 +17,5 @@ export function getContributing(repoName) {
 }
 
 export function getOpenIssues(repoName) {
-  return githubAxios.get(`/search/issues?q=repo:${repoName}+state:open&per_page=5`);
+  return githubAxios.get(`/search/issues?q=repo:${repoName}+state:open+is:issue&per_page=5`);
 }


### PR DESCRIPTION
Note:
For future ref to do PRs: 
```return githubAxios.get(`/search/issuesq=repo:${repoName}+state:open+is:pr&per_page=5`);```