### PR TITLE
Issue filtering

### DIFF
--- a/src/actions/resultsActionCreators.jsx
+++ b/src/actions/resultsActionCreators.jsx
@@ -14,6 +14,13 @@ export function updateResults(data) {
   }
 }
 
+export function updateOpenIssues(id, data) {
+  return function (dispatch) {
+    dispatch(updateResultOpenIssues(id, data.openIssues))
+    dispatch(updateResultSuggestedIssues(id, data.suggestedIssues))
+  }
+}
+
 export function updateResultContributing(id, data) {
   return {
     type: "RESULT_CONTRIBUTING_UPDATE",
@@ -26,7 +33,15 @@ export function updateResultOpenIssues(id, data) {
   return {
     type: "RESULT_OPEN_ISSUES_UPDATE",
     id,
-    payload: data.items
+    payload: data
+  }
+}
+
+export function updateResultSuggestedIssues(id, data) {
+  return {
+    type: "RESULT_SUGGESTED_ISSUES_UPDATE",
+    id,
+    payload: data
   }
 }
 

--- a/src/actions/searchActionCreators.jsx
+++ b/src/actions/searchActionCreators.jsx
@@ -1,5 +1,6 @@
 import * as resultsActions from './resultsActionCreators';
 import { searchGithub, getContributing, getOpenIssues } from '../utils/githubHelper';
+import { parseOpenIssues } from '../utils/openIssuesParser';
 
 /*
  * The action creators in the file will modify all of the parts of the redux state
@@ -34,7 +35,8 @@ export function getAdditionalInfo(id, repoName) {
           .then((response) => dispatch(resultsActions.updateResultContributing(id, response.data)))
           .catch((err) => dispatch(resultsActions.updateResultContributing(id, err.response.data))),
         getOpenIssues(repoName)
-          .then((response) => dispatch(resultsActions.updateResultOpenIssues(id, response.data)))
+          .then((response) => { return parseOpenIssues(response.data.items) })
+          .then((issues) => dispatch(resultsActions.updateOpenIssues(id, issues)))
           .catch((err, res) => { console.log(err) }) // Need to do something with these issues
       ]) // This will return a Promise, when the two promises inside this complete. This is used to set fetchingAdditionalInfo to false after both
       .then(responses => {

--- a/src/components/AdditionalInformationBox.jsx
+++ b/src/components/AdditionalInformationBox.jsx
@@ -18,7 +18,10 @@ export default class AdditionalInformationBox extends React.Component {
         <div>
           <ContributingInformationRow data={this.props.data.contributing} />
           <hr style={{width: "90%"}} />
-          <OpenIssuesRow data={this.props.data.openIssues}/>
+          <OpenIssuesRow
+            openIssues={this.props.data.openIssues}
+            suggestedIssues={this.props.data.suggestedIssues}
+          />
         </div>
       );
     } else {

--- a/src/components/OpenIssue.jsx
+++ b/src/components/OpenIssue.jsx
@@ -2,32 +2,31 @@ import React from 'react';
 import Label from './BsSpecialLabel';
 import '../styles/open-issue.css';
 
-const getBorder = (last=false) => {
-  if(!last) { return "1px solid #EAEAEA" };
+const getClasses = (last=false) => {
+  if(!last) { return "OpenIssue with-bottom-border" };
+  return "OpenIssue";
 }
 
-export default class OpenIssue extends React.Component {
-  render() {
-    const styles = {
-      borderBottom: getBorder(this.props.last)
-    };
-    const labels = this.props.data.labels.map((label, index) => {
-      return (
-        // Adding this class here allows me to leverage the spacing between labels
-        <span key={index} className='information-label'>
-          <Label fontSize="10px" color={`#${label.color}`}>{label.name}</Label>
-        </span>
-      );
-    });
-
+const OpenIssue = (props) => {
+  const classes = getClasses(props.last);
+  const labels = props.data.labels.map((label, index) => {
     return (
-      <div className="OpenIssue" style={styles}>
-        <a href={this.props.data.html_url}>
-          <strong>{this.props.data.title}</strong> <small>{` #${this.props.data.number} `}</small>
-        </a>
-        { labels }
-        <p className="created-at"><small>{`Opened on ${this.props.data.created_at}`}</small></p>
-      </div>
+      // Adding this class here allows me to leverage the spacing between labels
+      <span key={index} className='information-label'>
+        <Label fontSize="10px" color={`#${label.color}`}>{label.name}</Label>
+      </span>
     );
-  }
+  });
+
+  return (
+    <div className={classes}>
+      <a href={props.data.html_url}>
+        <strong>{props.data.title}</strong> <small>{` #${props.data.number} `}</small>
+      </a>
+      { labels }
+      <p className="created-at"><small>{`Opened on ${props.data.created_at}`}</small></p>
+    </div>
+  );
 }
+
+export default OpenIssue;

--- a/src/components/OpenIssue.jsx
+++ b/src/components/OpenIssue.jsx
@@ -2,8 +2,15 @@ import React from 'react';
 import Label from './BsSpecialLabel';
 import '../styles/open-issue.css';
 
+const getBorder = (last=false) => {
+  if(!last) { return "1px solid #EAEAEA" };
+}
+
 export default class OpenIssue extends React.Component {
   render() {
+    const styles = {
+      borderBottom: getBorder(this.props.last)
+    };
     const labels = this.props.data.labels.map((label, index) => {
       return (
         // Adding this class here allows me to leverage the spacing between labels
@@ -14,7 +21,7 @@ export default class OpenIssue extends React.Component {
     });
 
     return (
-      <div className="OpenIssue">
+      <div className="OpenIssue" style={styles}>
         <a href={this.props.data.html_url}>
           <strong>{this.props.data.title}</strong> <small>{` #${this.props.data.number} `}</small>
         </a>

--- a/src/components/OpenIssue.jsx
+++ b/src/components/OpenIssue.jsx
@@ -2,13 +2,9 @@ import React from 'react';
 import Label from './BsSpecialLabel';
 import '../styles/open-issue.css';
 
-const getClasses = (last=false) => {
-  if(!last) { return "OpenIssue with-bottom-border" };
-  return "OpenIssue";
-}
-
 const OpenIssue = (props) => {
-  const classes = getClasses(props.last);
+  // Shows bottom border if last === false
+  const classes = (props.last) ? "OpenIssue" : "OpenIssue with-bottom-border";
   const labels = props.data.labels.map((label, index) => {
     return (
       // Adding this class here allows me to leverage the spacing between labels
@@ -27,6 +23,10 @@ const OpenIssue = (props) => {
       <p className="created-at"><small>{`Opened on ${props.data.created_at}`}</small></p>
     </div>
   );
+}
+
+OpenIssue.defaultProps = {
+  last: false
 }
 
 export default OpenIssue;

--- a/src/components/OpenIssue.test.jsx
+++ b/src/components/OpenIssue.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import OpenIssue from './OpenIssue';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 describe('renders', () => {
   const data = {

--- a/src/components/OpenIssue.test.jsx
+++ b/src/components/OpenIssue.test.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import OpenIssue from './OpenIssue';
+import { shallow, mount } from 'enzyme';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
+describe('renders', () => {
   const data = {
     labels: [],
     title: "Test Issue",
@@ -11,5 +11,42 @@ it('renders without crashing', () => {
     number: 1,
     created_at: new Date()
   }
-  ReactDOM.render(<OpenIssue data={data} />, div);
+
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<OpenIssue data={data} />, div);
+  });
+  describe("bottom border rendering", () => {
+    describe('when props.last === true', () => {
+      it('does not include bottom border stlye', () => {
+        const wrapper = mount(<OpenIssue data={data} last={true} />);
+        expect(wrapper.find(".OpenIssue").get(0).style._values).toEqual({});
+      });
+    });
+    describe('when props.last != true', () => {
+      it('includes bottom border stlye', () => {
+        const wrapper = mount(<OpenIssue data={data} last={false} />);
+        expect(wrapper.find(".OpenIssue").get(0).style._values).toEqual({
+          "border-bottom": "1px solid #EAEAEA",
+          "border-bottom-color": "#EAEAEA",
+          "border-bottom-style": "solid",
+          "border-bottom-width": "1px"
+        });
+      });
+    });
+    describe('when props.last is undefined', () => {
+      it('includes bottom border stlye', () => {
+        const wrapper = mount(<OpenIssue data={data} />);
+        expect(wrapper.find(".OpenIssue").get(0).style._values).toEqual({
+          "border-bottom": "1px solid #EAEAEA",
+          "border-bottom-color": "#EAEAEA",
+          "border-bottom-style": "solid",
+          "border-bottom-width": "1px"
+        });
+      });
+    });
+  });
+  describe("label rendering", () => {
+
+  });
 });

--- a/src/components/OpenIssue.test.jsx
+++ b/src/components/OpenIssue.test.jsx
@@ -19,30 +19,20 @@ describe('renders', () => {
   describe("bottom border rendering", () => {
     describe('when props.last === true', () => {
       it('does not include bottom border stlye', () => {
-        const wrapper = mount(<OpenIssue data={data} last={true} />);
-        expect(wrapper.find(".OpenIssue").get(0).style._values).toEqual({});
+        const wrapper = shallow(<OpenIssue data={data} last={true} />);
+        expect(wrapper.find(".OpenIssue.with-bottom-border")).toHaveLength(0);
       });
     });
     describe('when props.last != true', () => {
       it('includes bottom border stlye', () => {
-        const wrapper = mount(<OpenIssue data={data} last={false} />);
-        expect(wrapper.find(".OpenIssue").get(0).style._values).toEqual({
-          "border-bottom": "1px solid #EAEAEA",
-          "border-bottom-color": "#EAEAEA",
-          "border-bottom-style": "solid",
-          "border-bottom-width": "1px"
-        });
+        const wrapper = shallow(<OpenIssue data={data} last={false} />);
+        expect(wrapper.find(".OpenIssue.with-bottom-border")).toHaveLength(1);
       });
     });
     describe('when props.last is undefined', () => {
       it('includes bottom border stlye', () => {
-        const wrapper = mount(<OpenIssue data={data} />);
-        expect(wrapper.find(".OpenIssue").get(0).style._values).toEqual({
-          "border-bottom": "1px solid #EAEAEA",
-          "border-bottom-color": "#EAEAEA",
-          "border-bottom-style": "solid",
-          "border-bottom-width": "1px"
-        });
+        const wrapper = shallow(<OpenIssue data={data} />);
+        expect(wrapper.find(".OpenIssue.with-bottom-border")).toHaveLength(1);
       });
     });
   });

--- a/src/components/OpenIssuesList.jsx
+++ b/src/components/OpenIssuesList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import OpenIssue from './OpenIssue';
-import { Col } from 'react-bootstrap';
+import '../styles/open-issues-list.css';
 
 const openIssuesDefaultProps = {
   issues: []
@@ -11,15 +11,24 @@ export default class OpenIssuesList extends React.Component {
 
   render() {
     const openIssues = this.props.issues.map((issue, index) => {
-      return <OpenIssue key={index} data={issue} />;
+      const last = (index === (this.props.issues.length - 1));
+      return <OpenIssue key={index} data={issue} last={last} />;
     });
-    return (
-      <div className="OpenIssuesList">
-        <Col xs={12} md={10} mdOffset={1}>
-          <h4>Open Issues</h4>
+
+    if(this.props.issues.length > 0) {
+      return (
+        <div className="OpenIssuesList">
+          { this.props.children }
           { openIssues }
-        </Col>
-      </div>
-    );
+        </div>
+      );
+    } else {
+      return (
+        <div className="OpenIssuesList">
+          { this.props.children }
+          <h5 className="text-center">No Open Issues Found</h5>
+        </div>
+      );
+    }
   }
 }

--- a/src/components/OpenIssuesList.test.jsx
+++ b/src/components/OpenIssuesList.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import OpenIssuesList from './OpenIssuesList';
+import { shallow } from 'enzyme';
 
 describe('render()', () => {
   it('renders without crashing', () => {
@@ -12,12 +13,57 @@ describe('render()', () => {
       number: 1,
       created_at: new Date()
     }];
-    ReactDOM.render(<OpenIssuesList data={data} />, div);
+    ReactDOM.render(<OpenIssuesList issues={data} />, div);
   });
-  describe('data is null', () => {
+  describe('issues is null', () => {
     it('renders without crashing', () => {
       const div = document.createElement('div');
       ReactDOM.render(<OpenIssuesList  />, div);
     });
   });
+  describe('when issues count <= 0', () => {
+    it('renders No Open Issues Found', () => {
+      const wrapper = shallow(<OpenIssuesList issues={[]} />);
+      expect(wrapper.contains(<h5 className="text-center">No Open Issues Found</h5>)).toBe(true);
+    });
+  });
+  describe('when issues count === 1', () => {
+    const issues = [
+      {
+        labels: [],
+        title: "Test Issue",
+        html_url: "test-issue-url.com",
+        number: 1,
+        created_at: new Date()
+      }
+    ]
+    const wrapper = shallow(<OpenIssuesList issues={issues} />);
+
+    it('renders one OpenIssue', () => {
+      expect(wrapper.find('OpenIssue')).toHaveLength(1);
+    });
+  });
+  describe('when issues count > 1', () => {
+    const issues = [
+      {
+        labels: [],
+        title: "Test Issue",
+        html_url: "test-issue-url.com",
+        number: 1,
+        created_at: new Date()
+      },
+      {
+        labels: [],
+        title: "Test Issue Two",
+        html_url: "test-issue-two-url.com",
+        number: 2,
+        created_at: new Date()
+      }
+    ]
+    const wrapper = shallow(<OpenIssuesList issues={issues} />);
+
+    it('renders multiple OpenIssue', () => {
+      expect(wrapper.find('OpenIssue')).toHaveLength(2);
+    });
+  })
 });

--- a/src/components/OpenIssuesRow.jsx
+++ b/src/components/OpenIssuesRow.jsx
@@ -2,29 +2,27 @@ import React from 'react';
 import OpenIssuesList from './OpenIssuesList';
 import { Row, Col } from 'react-bootstrap';
 
-const openIssuesDefaultProps = {
+const OpenIssuesRow = (props) => {
+  return (
+    <Row className="OpenIssuesRow">
+      <Col xs={12} md={10} mdOffset={1}>
+        <h3 style={{marginTop: "0px"}}>Open Issues</h3>
+        <hr />
+        <OpenIssuesList issues={props.suggestedIssues}>
+          <h4>Suggested Issues <small><i>These are open issues that are usually open for contributions or are those that are well suited for new contributors.</i></small></h4>
+        </OpenIssuesList>
+        <hr />
+        <OpenIssuesList issues={props.openIssues}>
+          <h4>Other Open Issues</h4>
+        </OpenIssuesList>
+      </Col>
+    </Row>
+  );
+}
+
+OpenIssuesRow.defaultProps = {
   openIssues: [],
   suggestedIssues: []
 }
 
-export default class OpenIssuesRow extends React.Component {
-  static defaultProps = openIssuesDefaultProps;
-
-  render() {
-    return (
-      <Row className="OpenIssuesRow">
-        <Col xs={12} md={10} mdOffset={1}>
-          <h3 style={{marginTop: "0px"}}>Open Issues</h3>
-          <hr />
-          <OpenIssuesList issues={this.props.suggestedIssues}>
-            <h4>Suggested Issues <small><i>These are open issues that are usually open for contributions or are those that are well suited for new contributors.</i></small></h4>
-          </OpenIssuesList>
-          <hr />
-          <OpenIssuesList issues={this.props.openIssues}>
-            <h4>Other Open Issues</h4>
-          </OpenIssuesList>
-        </Col>
-      </Row>
-    );
-  }
-}
+export default OpenIssuesRow;

--- a/src/components/OpenIssuesRow.jsx
+++ b/src/components/OpenIssuesRow.jsx
@@ -1,26 +1,30 @@
 import React from 'react';
 import OpenIssuesList from './OpenIssuesList';
+import { Row, Col } from 'react-bootstrap';
 
 const openIssuesDefaultProps = {
-  data: []
+  openIssues: [],
+  suggestedIssues: []
 }
 
 export default class OpenIssuesRow extends React.Component {
   static defaultProps = openIssuesDefaultProps;
 
   render() {
-    if(this.props.data.length > 0) {
-      return (
-        <div className="OpenIssuesRow">
-          <OpenIssuesList issues={this.props.data} />
-        </div>
-      );
-    } else {
-      return (
-        <div className="OpenIssuesRow">
-          <h5>No Open Issues Found</h5>
-        </div>
-      );
-    }
+    return (
+      <Row className="OpenIssuesRow">
+        <Col xs={12} md={10} mdOffset={1}>
+          <h3 style={{marginTop: "0px"}}>Open Issues</h3>
+          <hr />
+          <OpenIssuesList issues={this.props.suggestedIssues}>
+            <h4>Suggested Issues <small><i>These are open issues that are usually open for contributions or are those that are well suited for new contributors.</i></small></h4>
+          </OpenIssuesList>
+          <hr />
+          <OpenIssuesList issues={this.props.openIssues}>
+            <h4>Other Open Issues</h4>
+          </OpenIssuesList>
+        </Col>
+      </Row>
+    );
   }
 }

--- a/src/components/OpenIssuesRow.test.jsx
+++ b/src/components/OpenIssuesRow.test.jsx
@@ -1,25 +1,31 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { shallow } from 'enzyme';
 import OpenIssuesRow from './OpenIssuesRow';
 
 describe('render()', () => {
   describe('data length is greater than 0', () => {
+    const openIssues = [{
+      labels: [],
+      title: "Test Issue",
+      html_url: "test-issue-url.com",
+      number: 1,
+      created_at: new Date()
+    }];
+
     it('renders without crashing', () => {
       const div = document.createElement('div');
-      const data = [{
-        labels: [],
-        title: "Test Issue",
-        html_url: "test-issue-url.com",
-        number: 1,
-        created_at: new Date()
-      }];
-      ReactDOM.render(<OpenIssuesRow data={data} />, div);
+      ReactDOM.render(<OpenIssuesRow openIssues={openIssues} />, div);
+    });
+    it('includes two OpenIssuesList', () => {
+      const wrapper = shallow(<OpenIssuesRow openIssues={openIssues} />);
+      expect(wrapper.find("OpenIssuesList")).toHaveLength(2);
     });
   });
   describe('data length is NOT greater than 0', () => {
     it('renders without crashing', () => {
       const div = document.createElement('div');
-      ReactDOM.render(<OpenIssuesRow  data={[]} />, div);
+      ReactDOM.render(<OpenIssuesRow  openIssues={[]} />, div);
     });
   });
   describe('when data prop is not present', () => {

--- a/src/reducers/resultsReducer.jsx
+++ b/src/reducers/resultsReducer.jsx
@@ -6,6 +6,7 @@ export default function resultsReducer(state = initialState.results, action) {
     case "RESULT_CONTRIBUTING_UPDATE":
     case "RESULT_FETCHING_ADDITIONAL_INFO_UPDATE":
     case "RESULT_OPEN_ISSUES_UPDATE":
+    case "RESULT_SUGGESTED_ISSUES_UPDATE":
       const updatedData = objectAssign({}, state.data, {[action.id]: result(state.data[action.id], action)});
       return objectAssign({}, state, {data: updatedData});
     case "RESULTS_DATA_UPDATE":
@@ -21,6 +22,7 @@ function result(state, action) {
   switch(action.type) {
     case "RESULT_CONTRIBUTING_UPDATE":
     case "RESULT_OPEN_ISSUES_UPDATE":
+    case "RESULT_SUGGESTED_ISSUES_UPDATE":
       return objectAssign({}, state, { additionalInformation: additionalInformation(state.additionalInformation, action) });
     case "RESULT_FETCHING_ADDITIONAL_INFO_UPDATE":
       return objectAssign({}, state, { fetchingAdditional: action.payload });
@@ -35,6 +37,8 @@ function additionalInformation(state={}, action) {
       return objectAssign({}, state, { contributing: action.payload });
     case "RESULT_OPEN_ISSUES_UPDATE":
       return objectAssign({}, state, { openIssues: action.payload });
+    case "RESULT_SUGGESTED_ISSUES_UPDATE":
+      return objectAssign({}, state, { suggestedIssues: action.payload });
     default:
       return state;
   }

--- a/src/styles/open-issue.css
+++ b/src/styles/open-issue.css
@@ -3,6 +3,10 @@
   padding-top: 2px;
 }
 
+.OpenIssue.with-bottom-border {
+  border-bottom: 1px solid #EAEAEA;
+}
+
 .OpenIssue .created-at {
   font-size: 10px;
   margin-bottom: 0px;

--- a/src/styles/open-issue.css
+++ b/src/styles/open-issue.css
@@ -1,7 +1,6 @@
 .OpenIssue {
   padding-bottom: 2px;
   padding-top: 2px;
-  border-bottom: 1px solid #EAEAEA;
 }
 
 .OpenIssue .created-at {

--- a/src/styles/open-issues-list.css
+++ b/src/styles/open-issues-list.css
@@ -1,0 +1,4 @@
+.OpenIssuesList {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/src/utils/githubHelper.js
+++ b/src/utils/githubHelper.js
@@ -17,5 +17,5 @@ export function getContributing(repoName) {
 }
 
 export function getOpenIssues(repoName) {
-  return githubAxios.get(`/search/issues?q=repo:${repoName}+state:open+is:issue&per_page=5`);
+  return githubAxios.get(`/search/issues?q=repo:${repoName}+state:open+is:issue&per_page=15`);
 }

--- a/src/utils/openIssueParser.test.js
+++ b/src/utils/openIssueParser.test.js
@@ -1,0 +1,114 @@
+import { parseOpenIssues, suggested } from './openIssuesParser';
+
+describe('suggested()', () => {
+  describe('when issue has no labels', () => {
+    const issueWoLabels = {
+      title: "Test Issue",
+      labels: []
+    };
+    it('returns false', () => {
+      expect(suggested(issueWoLabels)).toEqual(false);
+    });
+  });
+  describe('when issue has suggested label', () => {
+    const issue = {
+      title: "Test Issue",
+      labels: [{ name: "help wanted" }]
+    };
+    it('returns true', () => {
+      expect(suggested(issue)).toEqual(true);
+    });
+    describe("when label is uppercased", () => {
+      it('still returns true', () => {
+        const upcaseIssue = {
+          title: "Test Issue",
+          labels: [{ name: "HELP WANTED" }]
+        }
+        expect(suggested(upcaseIssue)).toEqual(true);
+      });
+    });
+  });
+  describe('when issue has a bad label', () => {
+    const issue = {
+      title: "Test Issue",
+      labels: [
+        { name: "in progress" },
+        { name: "help wanted" }
+      ]
+    };
+    it('returns false', () => {
+      expect(suggested(issue)).toEqual(false);
+    });
+    describe("when label is uppercased", () => {
+      it('still returns false', () => {
+        const upcaseIssue = {
+          title: "Test Issue",
+          labels: [{ name: "IN PROGRESS" }]
+        }
+        expect(suggested(upcaseIssue)).toEqual(false);
+      });
+    });
+  });
+});
+
+describe('parseOpenIssues()', () => {
+  describe('when no issues exist', () => {
+    it('returns an object', () => {
+      expect(parseOpenIssues([])).toBeInstanceOf(Object);
+    });
+    it('returns object with [] for openIssues', () => {
+      const result = parseOpenIssues([]);
+      expect(result.openIssues).toEqual([]);
+    });
+    it('returns object with [] for suggestedIssues', () => {
+      const result = parseOpenIssues([]);
+      expect(result.suggestedIssues).toEqual([]);
+    });
+  });
+  describe('when issue(s) exist', () => {
+    describe('when suggestedIssue exists', () => {
+      const issues = [
+        {
+          title: "Test Issue",
+          labels: [{ name: "help wanted" }]
+        }
+      ]
+      const result = parseOpenIssues(issues);
+
+      it('includes issue in suggestedIssues', () => {
+        expect(result.suggestedIssues).toEqual([{
+          title: "Test Issue",
+          labels: [{ name: "help wanted" }]
+        }]);
+      });
+      it('does not include issue in openIssues', () => {
+        expect(result.openIssues).not.toContain({
+          title: "Test Issue",
+          labels: [{ name: "help wanted" }]
+        });
+      });
+    });
+    describe('when openIssue exists', () => {
+      const issues = [
+        {
+          title: "Test Issue",
+          labels: [{ name: "in progress" }]
+        }
+      ]
+      const result = parseOpenIssues(issues);
+
+      it('includes issue in openIssues', () => {
+        expect(result.openIssues).toEqual([{
+          title: "Test Issue",
+          labels: [{ name: "in progress" }]
+        }]);
+      });
+      it('does not include issue in suggestedIssues', () => {
+        expect(result.suggestedIssues).not.toContain({
+          title: "Test Issue",
+          labels: [{ name: "in progress" }]
+        });
+      });
+    });
+  });
+});

--- a/src/utils/openIssuesParser.js
+++ b/src/utils/openIssuesParser.js
@@ -1,0 +1,38 @@
+/*
+ * The following are the labels we have deemed should be searched for.
+ */
+const goodLabels = ["contributions welcome", "contributions: up for grabs", "contributions: up for grabs!", "help needed", "help wanted", "easy"]
+const badLabels = ["in progress", "claimed", "contributions: claimed"]
+
+export function parseOpenIssues(issues) {
+  let suggestedIssues = [];
+  let openIssues = [];
+
+  issues.forEach((issue) => {
+    if(suggested(issue)) {
+      suggestedIssues.push(issue);
+    } else {
+      openIssues.push(issue);
+    }
+  });
+
+  return {
+    openIssues: openIssues,
+    suggestedIssues: suggestedIssues
+  }
+}
+
+export function suggested(issue) {
+  if(issue.labels.length === 0) {
+    return false;
+  } else {
+    let suggestedIssue = false;
+    let badIssue = false;
+
+    issue.labels.forEach((label) => {
+      if(badLabels.includes(label.name)) badIssue = true;
+      if(goodLabels.includes(label.name.toLowerCase())) suggestedIssue = true;
+    });
+    return badIssue ? false : suggestedIssue;
+  }
+}


### PR DESCRIPTION
This PR adds the feature of displaying suggested issues for a repository. This means that we have a list of issue label names that usually indicate issues that need help or could be good for new contributions. On top of this, we also have a list of label names that indicate an issue is not open for contributions. We filter the issues for a repository off of these and display two lists, a `Suggested Issues` list and a `Other Open Issues` list.

This should be pretty good to go, but I'd like a code review if possible. @cubadomingo @AdamFreemer @dshrest any of you guys want to take a look for me?