### PR TITLE
Adding url-search-params polyfill for older browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "redux-logger": "2.8.2",
     "redux-thunk": "2.1.0",
     "remarkable": "1.7.1",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "url-search-params": "^0.9.0"
   },
   "devDependencies": {
     "enzyme": "^2.8.2",
@@ -34,8 +35,7 @@
     "react-test-renderer": "15.4.2",
     "redux-immutable-state-invariant": "1.2.4",
     "sinon": "^2.3.2",
-    "supertest": "^3.0.0",
-    "url-search-params-polyfill": "^1.2.0"
+    "supertest": "^3.0.0"
   },
   "scripts": {
     "start": "nf start -j Procfile.dev",

--- a/src/containers/SearchPage.jsx
+++ b/src/containers/SearchPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import URLSearchParams from 'url-search-params';
 import SearchBar from '../components/SearchBar';
 import SearchResultsBox from '../components/SearchResultsBox';
 import AppInfo from '../components/AppInfo';

--- a/src/containers/SearchPage.test.jsx
+++ b/src/containers/SearchPage.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-import 'url-search-params-polyfill';
 import { SearchPage } from './SearchPage';
 
 describe('SearchPage Container', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5551,9 +5551,9 @@ url-parse@^1.0.1, url-parse@^1.1.1:
     querystringify "0.0.x"
     requires-port "1.0.x"
 
-url-search-params-polyfill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-1.2.0.tgz#ad8150c701cd2005c2e8cc20ab5b683dd0372b16"
+url-search-params@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/url-search-params/-/url-search-params-0.9.0.tgz#e71d7764a6503533cbfe9771b2963cb61ea1c225"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Solves some browser compatibility issues with older versions of safari, chrome, etc.