### PR TITLE
Stagger animation for each search result

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dotenv": "^4.0.0",
     "express": "^4.15.2",
     "foreman": "^2.0.0",
+    "gsap": "^1.20.2",
     "halogen": "0.2.0",
     "leaflet": "^1.0.3",
     "lodash": "^4.17.4",

--- a/src/components/SearchResultsList.jsx
+++ b/src/components/SearchResultsList.jsx
@@ -1,12 +1,24 @@
 import React from 'react';
+import TweenMax from 'gsap';
 import SearchResult from './SearchResult';
 
 export default class SearchResultsList extends React.Component {
+  componentDidMount() {
+    // eslint-disable-next-line
+    TweenMax.staggerFrom('.animate', 1, { scale: 0.5, opacity: 0, delay: 0.5, ease: Linear.easeOut }, 0.2);
+  }
   render() {
     const { results, sortedIds, getAdditionalInfo } = this.props
 
     const sortedResults = sortedIds.map((id) => {
-      return <SearchResult key={id} data={results[id]} getAdditionalInfo={getAdditionalInfo} />
+      return (
+        <div key={id} className="animate">
+          <SearchResult
+            data={results[id]}
+            getAdditionalInfo={getAdditionalInfo}
+          />
+        </div>
+      )
     });
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2448,6 +2448,10 @@ growly@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+gsap@^1.20.2:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/gsap/-/gsap-1.20.2.tgz#c78abd906c32ee21964c1b90f921b5110180c65a"
+
 gzip-size@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"


### PR DESCRIPTION
This feature adds a stagger animation to the search results with just one line of code!! Thank you green sock.

All specs passing locally.

The eslint-disable line is needed to allow webpack to compile otherwise eslint throws an error. Another option is to add the gsap global variables to the eslint configuration file so eslint whitelists them.

Also feel free to play around with the Ease: option in the staggerFrom() method.