### PR TITLE
stubs out console error to prevent rendering warning in the terminal

### DIFF
--- a/src/components/contributors-map/__tests__/MapMarker.test.js
+++ b/src/components/contributors-map/__tests__/MapMarker.test.js
@@ -1,14 +1,21 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import MapMarker from '../MapMarker';
 
 describe('MapMarker', () => {
   describe('props validation', () => {
     describe('when no location prop exists', () => {
       it('raises error when rendering', () => {
+        // stubs console.error to prevent rendering in the terminal
+        const stub = sinon.stub(console, 'error');
+
         expect(() => {
           shallow(<MapMarker />);
-        }).toThrow();
+        }).toThrow(new TypeError("Cannot read property 'latitude' of undefined"));
+        expect(stub.calledOnce).toEqual(true);
+
+        console.error.restore();
       });
     });
   });

--- a/src/components/contributors-map/__tests__/MapMarkerPopupInformation.test.js
+++ b/src/components/contributors-map/__tests__/MapMarkerPopupInformation.test.js
@@ -1,13 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import MapMarkerPopupInformation from '../MapMarkerPopupInformation';
 
 describe('MapMarkerPopupInformation', () => {
   describe('when no location prop exists', () => {
     it('raises error when rendering', () => {
+      // stubs console.error to prevent rendering in the terminal
+      const stub = sinon.stub(console, 'error');
+
       expect(() => {
         shallow(<MapMarkerPopupInformation />);
-      }).toThrow();
+      }).toThrow(new TypeError("Cannot read property 'name' of undefined"));
+      expect(stub.calledOnce).toEqual(true);
+
+      console.error.restore();
     });
   });
   describe('with props', () => {


### PR DESCRIPTION
I am stubbing out the console.error method to prevent warnings in the terminal when running tests. I then test the stub to ensure that the proptypes console.error has been called. I also compare the throw error to match the expected error when location is omitted.